### PR TITLE
Fiks 'pretty-commit'-script til å fungere med Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "pretty-please": "pretty-quick --staged",
-    "pretty-commit": "pretty-quick --staged --pattern '**/*.*(ts|tsx|js)'",
+    "pretty-commit": "pretty-quick --staged --pattern \"**/*.*(ts|tsx|js)\"",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -24,8 +24,6 @@
     "dayjs": "^1.11.0",
     "nanoid": "^4.0.0",
     "next": "^12.1.4",
-    "prettier": "^2.6.0",
-    "pretty-quick": "^3.1.3",
     "prop-types": "^15.8.1",
     "react": "^18.0.0",
     "react-day-picker": "^8.0.2",
@@ -46,6 +44,8 @@
     "husky": "^7.0.4",
     "jest": "^28.1.1",
     "jest-environment-jsdom": "^28.1.1",
+    "prettier": "^2.7.1",
+    "pretty-quick": "^3.1.3",
     "timezone-mock": "^1.3.1",
     "typescript": "4.6.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4170,10 +4170,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-prettier@^2.6.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION
@MrFjellstad Kan du sjekke om script-endringen fungerer på Mac?

Jeg er ikke sikker på hvordan dere pleier å gjøre det i teamet, men jeg sniker ofte småting som må fikses med i PR-ene mine. Her har jeg sneket `prettier` og `pretty-quick` bort fra `"dependencies"` og over til `"devDependencies"`, der de vel hører hjemme? `prettier` er også bumpet fra `2.6.2` til `2.7.1`.