### PR TITLE
Sender ikke inn dato om refusjon ikke opphører

### DIFF
--- a/__tests__/state/useFyllInnsending.test.ts
+++ b/__tests__/state/useFyllInnsending.test.ts
@@ -22,7 +22,7 @@ function fetchMock(url, suffix = '') {
             data: inntektData
           })
       });
-    }, 200 + Math.random() * 300)
+    }, 20)
   );
 }
 
@@ -76,7 +76,7 @@ describe('useFyllInnsending', () => {
     }
   });
 
-  it('should fill the state stuff', async () => {
+  it('should fill the state stuff - delvis', async () => {
     const { result } = renderHook(() => useBoundStore((state) => state));
 
     const { result: kvittInit } = renderHook(() => useKvitteringInit());
@@ -109,7 +109,7 @@ describe('useFyllInnsending', () => {
       ]);
       expect(innsending.refusjon.utbetalerHeleEllerDeler).toBeFalsy();
       expect(innsending.refusjon.refusjonPrMnd).toBeUndefined();
-      expect(innsending.refusjon.refusjonOpphører).toBeUndefined();
+      expect(innsending.refusjon.refusjonOpphører).toBe('2023-04-19');
       expect(innsending.refusjon.refusjonEndringer).toBeUndefined();
       expect(innsending.inntekt.beregnetInntekt).toBe(80666.66666666667);
       expect(innsending.inntekt.bekreftet).toBeTruthy();

--- a/__tests__/validators/valdiderEndringAvMaanedslonn.test.ts
+++ b/__tests__/validators/valdiderEndringAvMaanedslonn.test.ts
@@ -28,7 +28,7 @@ describe.concurrent('valdiderEndringAvMaanedslonn', () => {
       },
       {
         code: 'MANGLER_DATO',
-        felt: 'lus-utbetaling-endring-dato-0'
+        felt: 'refusjon.refusjonEndringer[0].dato'
       }
     ]);
   });

--- a/components/RefusjonArbeidsgiver/RefusjonUtbetalingEndring.tsx
+++ b/components/RefusjonArbeidsgiver/RefusjonUtbetalingEndring.tsx
@@ -117,9 +117,9 @@ export default function RefusjonUtbetalingEndring({
               fromDate={minDate}
               toDate={maxDate}
               onDateChange={(val: Date | undefined) => changeDatoHandler(val, key)}
-              id={`lus-utbetaling-endring-dato-${key}`}
+              id={`refusjon.refusjonEndringer[${key}].dato`}
               label='Dato for endring'
-              error={visFeilmeldingsTekst(`lus-utbetaling-endring-dato-${key}`)}
+              error={visFeilmeldingsTekst(`refusjon.refusjonEndringer[${key}].dato`)}
               defaultSelected={endring.dato}
             />
             {key !== 0 && (

--- a/state/useFyllInnsending.ts
+++ b/state/useFyllInnsending.ts
@@ -248,7 +248,7 @@ export default function useFyllInnsending() {
         utbetalerHeleEllerDeler: lonnISykefravaeret?.status === 'Ja',
         refusjonPrMnd: jaEllerNei(lonnISykefravaeret?.status, lonnISykefravaeret?.belop),
         refusjonOpphører: jaEllerNei(
-          lonnISykefravaeret?.status,
+          refusjonskravetOpphoerer?.status,
           refusjonskravetOpphoerer?.opphorsdato ? formatIsoDate(refusjonskravetOpphoerer?.opphorsdato) : undefined
         ),
         refusjonEndringer: jaEllerNei(lonnISykefravaeret?.status, innsendingRefusjonEndringer)

--- a/validators/validerEndringAvMaanedslonn.ts
+++ b/validators/validerEndringAvMaanedslonn.ts
@@ -38,7 +38,7 @@ export default function valdiderEndringAvMaanedslonn(
 
       if (!endring.dato) {
         feilmeldinger.push({
-          felt: `lus-utbetaling-endring-dato-${index}`,
+          felt: `refusjon.refusjonEndringer[${index}].dato`,
           code: EndringAvMaanedslonnFeilkode.MANGLER_DATO
         });
       }


### PR DESCRIPTION
Fikser en bug hvor dato for refusjon opphører ble sendt inn samme hva, så lenge den var satt en gang.