### PR TITLE
Fiks noen småbugs på selvbestemt (og vanlig) skjema

### DIFF
--- a/components/RefusjonArbeidsgiver/RefusjonArbeidsgiver.tsx
+++ b/components/RefusjonArbeidsgiver/RefusjonArbeidsgiver.tsx
@@ -150,7 +150,7 @@ export default function RefusjonArbeidsgiver({ setIsDirtyForm }: RefusjonArbeids
           id={'lus-radio'}
           error={visFeilmeldingsTekst('lus-radio')}
           onChange={addIsDirtyForm(arbeidsgiverBetalerHeleEllerDelerAvSykefravaeret)}
-          // defaultValue={lonnISykefravaeret?.status}
+          defaultValue={lonnISykefravaeret?.status}
         >
           <Radio value='Ja'>Ja</Radio>
           <Radio value='Nei'>Nei</Radio>

--- a/mockdata/selvbestemt-kvittering.json
+++ b/mockdata/selvbestemt-kvittering.json
@@ -17,7 +17,16 @@
       "redusertLoennIAgp": { "beloep": 5000, "begrunnelse": "ArbeidOpphoert" }
     },
     "inntekt": { "beloep": 1230, "inntektsdato": "2024-06-03", "naturalytelser": [], "endringAarsak": null },
-    "refusjon": null,
+    "refusjon": {
+      "beloepPerMaaned": 45000,
+      "endringer": [
+        {
+          "beloep": 35000,
+          "startdato": "2024-05-08"
+        }
+      ],
+      "sluttdato": "2024-06-05"
+    },
     "aarsakInnsending": "Ny",
     "mottatt": "2024-06-12T12:38:18.337459713+02:00"
   }

--- a/pages/kvittering/agi/[kvittid].tsx
+++ b/pages/kvittering/agi/[kvittid].tsx
@@ -215,8 +215,8 @@ const Kvittering: NextPage<InferGetServerSidePropsType<typeof getServerSideProps
   let loenn: LonnISykefravaeret = { status: undefined, beloep: 0 };
   if (dataFraBackend) {
     loenn = {
-      status: kvitteringDokument.refusjon?.utbetalerHeleEllerDeler ? 'Ja' : 'Nei',
-      beloep: kvitteringDokument.refusjon?.refusjonPrMnd
+      status: kvitteringDokument.refusjon ? 'Ja' : 'Nei',
+      beloep: kvitteringDokument.refusjon?.beloepPerMaaned
     };
   } else {
     loenn = {
@@ -228,8 +228,8 @@ const Kvittering: NextPage<InferGetServerSidePropsType<typeof getServerSideProps
   let refusjonskravetOpphoerer: RefusjonskravetOpphoerer = { status: undefined, opphoersdato: undefined };
   if (dataFraBackend) {
     refusjonskravetOpphoerer = {
-      status: kvitteringDokument?.refusjon?.refusjonOpphører ? 'Ja' : ('Nei' as YesNo),
-      opphoersdato: parseIsoDate(kvitteringDokument.refusjon?.refusjonOpphører)
+      status: kvitteringDokument?.refusjon?.sluttdato ? 'Ja' : ('Nei' as YesNo),
+      opphoersdato: parseIsoDate(kvitteringDokument.refusjon?.sluttdato)
     };
   } else {
     refusjonskravetOpphoerer = {
@@ -240,9 +240,9 @@ const Kvittering: NextPage<InferGetServerSidePropsType<typeof getServerSideProps
 
   let refusjonEndringer = [];
   if (dataFraBackend) {
-    refusjonEndringer = kvitteringDokument?.refusjon?.refusjonEndringer?.map((endring) => ({
-      dato: parseIsoDate(endring.dato),
-      beloep: endring.beløp
+    refusjonEndringer = kvitteringDokument?.refusjon?.endringer?.map((endring) => ({
+      dato: parseIsoDate(endring.startdato),
+      beloep: endring.beloep
     }));
   } else {
     refusjonEndringer = kvitteringData?.refusjon?.endringer
@@ -436,10 +436,15 @@ function prepareForInitiering(kvitteringData: any, personData: PersonData) {
   kvittering.beregnetInntekt = kvitteringData.inntekt.beloep;
 
   kvittering.refusjon = {
-    utbetalerHeleEllerDeler: kvitteringData.refusjon?.betalerHeleEllerDeler ? true : false,
+    utbetalerHeleEllerDeler: kvitteringData.refusjon?.beloepPerMaaned ? true : false,
     refusjonPrMnd: kvitteringData.refusjon?.beloepPerMaaned,
     refusjonOpphører: kvitteringData.refusjon?.sluttdato,
-    refusjonEndringer: kvitteringData.refusjon?.endringer ? kvitteringData.refusjon?.endringer : []
+    refusjonEndringer: kvitteringData.refusjon?.endringer
+      ? kvitteringData.refusjon?.endringer.map((endring) => ({
+          dato: endring.startdato,
+          beløp: endring.beloep
+        }))
+      : []
   };
 
   kvittering.fullLønnIArbeidsgiverPerioden = {

--- a/state/useFyllInnsending.ts
+++ b/state/useFyllInnsending.ts
@@ -297,11 +297,11 @@ function formaterOpphørsdato(
   kreverIkkeRefusjon: boolean,
   refusjonskravetOpphoerer: RefusjonskravetOpphoerer | undefined
 ): string | undefined {
-  return !kreverIkkeRefusjon
-    ? refusjonskravetOpphoerer?.opphoersdato
-      ? formatIsoDate(refusjonskravetOpphoerer?.opphoersdato)
-      : undefined
-    : undefined;
+  let opphørsdato;
+  if (!kreverIkkeRefusjon && refusjonskravetOpphoerer?.status === 'Ja' && refusjonskravetOpphoerer?.opphoersdato) {
+    opphørsdato = formatIsoDate(refusjonskravetOpphoerer?.opphoersdato);
+  }
+  return opphørsdato;
 }
 
 function nyEllerEndring(nyInnsending: boolean) {

--- a/utils/useSendInnArbeidsgiverInitiertSkjema.ts
+++ b/utils/useSendInnArbeidsgiverInitiertSkjema.ts
@@ -114,6 +114,13 @@ export default function useSendInnArbeidsgiverInitiertSkjema(
         });
       }
 
+      if (refusjonskravetOpphoerer?.status === 'Ja' && !refusjonskravetOpphoerer?.opphoersdato) {
+        errors.push({
+          text: 'Angi siste dato det kreves refusjon for.',
+          felt: 'lus-sluttdato'
+        });
+      }
+
       if (!opplysningerBekreftet) {
         errors.push({
           text: feiltekster.BEKREFT_OPPLYSNINGER,

--- a/utils/useSendInnArbeidsgiverInitiertSkjema.ts
+++ b/utils/useSendInnArbeidsgiverInitiertSkjema.ts
@@ -75,7 +75,8 @@ export default function useSendInnArbeidsgiverInitiertSkjema(
       (!harRefusjonEndringer && lonnISykefravaeret?.status === 'Ja') ||
       !fullLonnIArbeidsgiverPerioden?.status ||
       !lonnISykefravaeret?.status ||
-      (!refusjonskravetOpphoerer?.status && lonnISykefravaeret?.status === 'Ja')
+      (!refusjonskravetOpphoerer?.status && lonnISykefravaeret?.status === 'Ja') ||
+      (refusjonskravetOpphoerer?.status === 'Ja' && !refusjonskravetOpphoerer?.opphoersdato)
     ) {
       const errors: ValiderTekster[] = hasErrors
         ? validerteData.error.issues.map((issue) => {


### PR DESCRIPTION
**Bakgrunn**
Vi ønsker å fikse noen bugs før vi går i prod med det selvbestemte skjemaet.

**Løsning**
1. Reflekter navneendringer i backend for refusjon, sånn at refusjon blir med på kvitteringen.
2. Legg til validering på siste dato det kreves refusjon for, sånn at vi alltid får med en dato dersom man huker av ja på spørsmålet om refusjonskravet opphører.
3. Ta med en default-verdi som har blitt kommentert ut tidligere for å få tilbake den tidligere utfylte verdien til `Betaler arbeidsgiver lønn og krever refusjon etter arbeidsgiverperioden?` når man går inn for å endre tidligere innsendt skjema.
4. Fikser en bug der gammel sluttdato for refusjon blir sendt inn dersom man endrer fra "Ja" til "Nei" på spørsmålet om refusjon har en sluttdato.

