### PR TITLE
Juster infotekst ved arbeidsgiverinitiert utfylling dersom antall sykedager er mer enn 16

### DIFF
--- a/pages/initiering2/index.tsx
+++ b/pages/initiering2/index.tsx
@@ -244,11 +244,12 @@ const Initiering2: NextPage = () => {
                     <PeriodeVelger perioder={perioder} />
                     {antallSykedager > 16 && (
                       <Alert variant='info' className={lokalStyles.alertPadding}>
-                        <Heading1>Er du sikker på at du skal opprette inntektsmelding nå?</Heading1>
+                        <Heading1>Er du sikker på at du skal opprette inntektsmelding manuelt?</Heading1>
                         Vi sender ut varsel når arbeidsgiverperioden er over og den sykmeldte har sendt inn søknad om
-                        sykepenger. Hvis du ikke har fått varsel og en{' '}
-                        <Link href={environment.saksoversiktUrl}>oppgave i saksoversikten</Link> er det mulig å opprette
-                        den manuelt her.
+                        sykepenger. Vi anbefaler at dere venter til dere har fått varselet, og at dere sender inn
+                        inntektsmeldingen via mottatt{' '}
+                        <Link href={environment.saksoversiktUrl}>oppgave i saksoversikten</Link>. Innsending av
+                        inntektsmelding manuelt kan gjøre at behandlingen av saken stopper opp.
                       </Alert>
                     )}
                   </>


### PR DESCRIPTION
**Bakgrunn**
Vi ønsker en litt strengere utgave av denne teksten for å forhindre at brukere sender inn arbeidsgiverinitierte inntektsmeldinger i tilfeller der de egentlig bør vente på varsel og sende gjennom den vanlige flyten.

**Løsning**
Bytt til strengere tekst.